### PR TITLE
Separated document updating logic from data classes and UI

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,24 +1,11 @@
-import dataClasses.Document
 import github.RepoHandler
 import dataClasses.RepoNode
 import dataClasses.FolderNode
 import dataClasses.FileNode
-import dataClasses.addCode
-import dataClasses.addHeading
-import dataClasses.addImage
-import dataClasses.addParagraph
 import github.MockRepoNode
-import java.util.Base64
 import ui.App
-import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.runtime.*
-import androidx.compose.material.Text
-import androidx.compose.material.Button
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import documentManager.DocumentStorage
-import kotlinx.coroutines.runBlocking
-import java.io.File
 
 fun main() = application {
     // To use (my) real repository

--- a/src/main/kotlin/dataClasses/Document.kt
+++ b/src/main/kotlin/dataClasses/Document.kt
@@ -1,6 +1,8 @@
 package dataClasses
 
 import DocumentItem
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
@@ -17,18 +19,3 @@ data class Document(
     val repoName: String,
     val parts: MutableList<DocumentItem> = mutableListOf(),
 )
-
-/**
- * Appending items to the document item list
- */
-fun Document.addHeading(text: String) =
-    parts.add(DocumentItem.Heading(text))
-
-fun Document.addParagraph(text: String) =
-    parts.add(DocumentItem.Paragraph(text))
-
-fun Document.addImage(title: String, relativePath: String) =
-    parts.add(DocumentItem.Image(title, relativePath))
-
-fun Document.addCode(filePath: String, code: String) =
-    parts.add(DocumentItem.Code(filePath, code))

--- a/src/main/kotlin/documentEditHandler/DocumentEditor.kt
+++ b/src/main/kotlin/documentEditHandler/DocumentEditor.kt
@@ -1,0 +1,41 @@
+package documentEditHandler
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import dataClasses.Document
+
+/**
+ * Handler that is responsible for the editing of the user
+ * interface
+ */
+class DocumentEditor(
+    initial: Document,
+) {
+    var document by mutableStateOf(initial)
+        private set
+
+    fun addHeading(text: String) {
+        document = document.copy(
+            parts = (document.parts + DocumentItem.Heading(text)).toMutableList()
+        )
+    }
+
+    fun addParagraph(text: String) {
+        document = document.copy(
+            parts = (document.parts + DocumentItem.Paragraph(text)).toMutableList()
+        )
+    }
+
+    fun addCode(filePath: String, code: String) {
+        document = document.copy(
+            parts = (document.parts + DocumentItem.Code(filePath, code)).toMutableList()
+        )
+    }
+
+    fun addImage(title: String, relativePath: String) {
+        document = document.copy(
+            parts = (document.parts + DocumentItem.Image(title, relativePath)).toMutableList()
+        )
+    }
+}

--- a/src/main/kotlin/ui/DocumenterView.kt
+++ b/src/main/kotlin/ui/DocumenterView.kt
@@ -4,11 +4,13 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.material.Text
@@ -19,13 +21,7 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import dataClasses.Document
-import dataClasses.RepoNode
 import java.io.File
-
-data class PendingImage(
-    val fileName: String,
-    val bytes: ByteArray,
-)
 
 @Composable
 fun ImageBlock(image: DocumentItem.Image) {
@@ -43,7 +39,9 @@ fun ImageBlock(image: DocumentItem.Image) {
         Image(
             bitmap = bitmap,
             contentDescription = image.fileName,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 400.dp)
         )
     } else {
         Text("Image doesn't exist.", color = Color.Gray)
@@ -67,19 +65,21 @@ fun CodeBlock(code: DocumentItem.Code) {
 
 @Composable
 fun DocumenterView(document: Document) {
-    Column(
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        Text(
-            text = document.title,
-            style = MaterialTheme.typography.h5
-        )
+        item {
+            Text(
+                text = document.title,
+                style = MaterialTheme.typography.h5
+            )
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+        }
 
-        for (item in document.parts) {
+        items(document.parts) { item ->
             when (item) {
                 is DocumentItem.Heading -> {
                     Text(
@@ -87,19 +87,22 @@ fun DocumenterView(document: Document) {
                         style = MaterialTheme.typography.h6
                     )
                 }
+
                 is DocumentItem.Paragraph -> {
                     Text(
                         text = item.text,
                     )
                 }
+
                 is DocumentItem.Code -> {
                     CodeBlock(item)
                 }
+
                 is DocumentItem.Image -> {
                     ImageBlock(item)
                 }
             }
+            Spacer(modifier = Modifier.height(8.dp))
         }
     }
-
 }

--- a/src/test/kotlin/documentManager/DocumentStorageTest.kt
+++ b/src/test/kotlin/documentManager/DocumentStorageTest.kt
@@ -3,7 +3,7 @@ package documentManager
 import dataClasses.Document
 import java.io.File
 import DocumentItem
-import dataClasses.addCode
+import documentEditHandler.DocumentEditor
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -38,35 +38,40 @@ class DocumentStorageTest {
 
     @Test
     fun `add code snippet`() {
-        val doc = Document(
-            title = "My First Doc",
-            repoName = "repo"
+        val editor = DocumentEditor(
+            Document(
+                title = "My First Doc",
+                repoName = "repo"
+            )
         )
 
-        doc.addCode(
+        editor.addCode(
             filePath = "src/Main.kt",
             code = "fun main() { println(\"Hello\") }"
         )
 
-        assertEquals(1, doc.parts.size)
-        assertTrue(doc.parts.first() is DocumentItem.Code)
+        assertEquals(1, editor.document.parts.size)
+        assertTrue(editor.document.parts.first() is DocumentItem.Code)
     }
 
     @Test
     fun `code snippet preserves file path and code`() {
-        val doc = Document(
-            title = "My First Doc",
-            repoName = "repo"
+        val editor = DocumentEditor(
+            Document(
+                title = "My First Doc",
+                repoName = "repo"
+            )
         )
+
         val filePath = "src/Main.kt"
         val code = "fun main() { println(\"Hello\") }"
-        doc.addCode(
+        editor.addCode(
             filePath = filePath,
             code = code
         )
 
-        assertEquals(1, doc.parts.size)
-        val codeItem = doc.parts.first() as DocumentItem.Code
+        assertEquals(1, editor.document.parts.size)
+        val codeItem = editor.document.parts.first() as DocumentItem.Code
         assertEquals(filePath, codeItem.filePath)
         assertEquals(code, codeItem.code)
     }


### PR DESCRIPTION
Document updating logic was all over the place, original vision was unclear and the functions in the data class weren't actually used, instead done directly in the UI.
Now a DocumentEditor handler takes care of the logic, when it's called in the UI. The immutable nature is still kept in the logic.